### PR TITLE
registry: support aliyun registry

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -498,6 +498,10 @@ func (r *dockerBase) fetchTokenWithOAuth(ctx context.Context, to tokenOptions) (
 		return "", fmt.Errorf("unable to decode token response: %s", err)
 	}
 
+	if tr.AccessToken == "" {
+		return r.getToken(ctx, to)
+	}
+
 	return tr.AccessToken, nil
 }
 


### PR DESCRIPTION
since containerd just support OAuth2 authentication, the
patch is for compatible registries who do not implement
OAuth2 authentication，especially for aliyun registry:
reg.docker.alibaba-inc.com

Signed-off-by: Ace-Tang <aceapril@126.com>