### PR TITLE
pass image label to snapshot

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,6 +253,13 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 		}
 	}
 
+	if pullCtx.Labels == nil {
+		pullCtx.Labels = make(map[string]string)
+	}
+
+	// add label type=image to image labels
+	pullCtx.Labels[snapshots.TypeLabelKey] = snapshots.ImageType
+
 	imgrec := images.Image{
 		Name:   name,
 		Target: desc,
@@ -556,6 +563,12 @@ func (c *Client) Import(ctx context.Context, importer images.Importer, reader io
 		} else {
 			imgrec = updated
 		}
+
+		if imgrec.Labels == nil {
+			imgrec.Labels = make(map[string]string)
+		}
+		// add label type=image to pass to snapshot
+		imgrec.Labels[snapshots.TypeLabelKey] = snapshots.ImageType
 
 		images = append(images, &image{
 			client: c,

--- a/image.go
+++ b/image.go
@@ -9,6 +9,8 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
+	"github.com/containerd/containerd/snapshots"
+
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -99,15 +101,16 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 	}
 
 	var (
-		sn = i.client.SnapshotService(snapshotterName)
-		a  = i.client.DiffService()
-		cs = i.client.ContentStore()
+		sn  = i.client.SnapshotService(snapshotterName)
+		a   = i.client.DiffService()
+		cs  = i.client.ContentStore()
+		opt = snapshots.WithLabels(i.i.Labels)
 
 		chain    []digest.Digest
 		unpacked bool
 	)
 	for _, layer := range layers {
-		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a)
+		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a, opt)
 		if err != nil {
 			return err
 		}

--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -327,7 +327,8 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 		if readonly {
 			m, err = s.Snapshotter.View(ctx, bkey, bparent)
 		} else {
-			m, err = s.Snapshotter.Prepare(ctx, bkey, bparent)
+			// pass snapshot opts to Snapshotter Prepare
+			m, err = s.Snapshotter.Prepare(ctx, bkey, bparent, opts...)
 		}
 		return err
 	}); err != nil {

--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -9,6 +9,12 @@ import (
 	"github.com/containerd/containerd/mount"
 )
 
+//add label type=image in Snapshotter metadata Info.Labels to indicate the snapshot for image.
+const (
+	TypeLabelKey = "type"
+	ImageType    = "image"
+)
+
 // Kind identifies the kind of snapshot.
 type Kind uint8
 


### PR DESCRIPTION
When a image unpacks, invoker could set labels to images, and pass labels to snapshot which is prepared for image. In snapshotter method such as Prepare  and Commit, we can differ image and container snapshot by labels.
